### PR TITLE
ciがlintとjestでciが落ちる調査

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Workflow
 
 on:
   workflow_dispatch:
@@ -16,9 +16,10 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.9.0'
+          node-version: '20.x'
       - name: Install dependencies & test
         run: |
+          rm -rf node_modules & rm -rf yarn.lock
           yarn
           yarn build
           yarn test

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prettier:write": "prettier --write \"**/*.{ts,tsx}\"",
     "jest": "jest",
     "jest:watch": "jest --watch",
-    "test": "npm run typecheck && npm run prettier && npm run build",
+    "test": "npm run typecheck && npm run prettier && npm run lint && npm run jest && npm run build",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
     "prepare": "husky install"


### PR DESCRIPTION
エラー内容
```
There was a problem loading formatter: /home/runner/work/vite-mantine/vite-mantine/node_modules/eslint/lib/cli-engine/formatters/stylish
Error: require() of ES Module /home/runner/work/vite-mantine/vite-mantine/node_modules/strip-ansi/index.js from /home/runner/work/vite-mantine/vite-mantine/node_modules/eslint/lib/cli-engine/formatters/stylish.js not supported.
Instead change the require of index.js in /home/runner/work/vite-mantine/vite-mantine/node_modules/eslint/lib/cli-engine/formatters/stylish.js to a dynamic import() which is available in all CommonJS modules.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

node_modulesとyarn.lockを削除して対応する
https://github.com/nrwl/nx/issues/17229#issuecomment-1568293388